### PR TITLE
[FEAT] TMDB - 영화 데이터 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,11 @@ dependencies {
 	// Config Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
-	//Swagger
+	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/flipflick/backend/api/movie/controller/MovieController.java
+++ b/src/main/java/com/flipflick/backend/api/movie/controller/MovieController.java
@@ -1,0 +1,37 @@
+package com.flipflick.backend.api.movie.controller;
+
+import com.flipflick.backend.api.movie.dto.MovieDetailResponseDTO;
+import com.flipflick.backend.api.movie.dto.SearchRequestIdDTO;
+import com.flipflick.backend.api.movie.service.MovieService;
+import com.flipflick.backend.common.response.ApiResponse;
+import com.flipflick.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/movie")
+@Tag(name="Movie", description = "영화 관련 API 입니다.")
+public class MovieController {
+
+    private final MovieService movieService;
+
+    @Operation(summary = "영화 상세 조회 API", description = "TMDB ID를 받아 영화 상세 데이터를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "영화 상세 정보 조회 성공")
+    })
+    @PostMapping("/view")
+    public ResponseEntity<ApiResponse<MovieDetailResponseDTO>> viewMovieDetail(@RequestBody SearchRequestIdDTO searchRequestIdDTO) throws Exception {
+
+        MovieDetailResponseDTO movieDetailResponseDTO = movieService.viewMovieDetail(searchRequestIdDTO);
+        return ApiResponse.success(SuccessStatus.SEND_MOVIE_DETAIL_SUCCESS, movieDetailResponseDTO);
+    }
+
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/CastResponseDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/CastResponseDTO.java
@@ -1,0 +1,12 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CastResponseDTO {
+    private Long id;          // 배우 TMDB ID
+    private String name;      // 배우 이름
+    private String profileImg; // 프로필 이미지 URL
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/GenreDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/GenreDTO.java
@@ -1,0 +1,11 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GenreDTO {
+    private Long tmdbId;
+    private String genreName;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/MovieDetailResponseDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/MovieDetailResponseDTO.java
@@ -1,0 +1,32 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class MovieDetailResponseDTO {
+
+    private Long tmdbId;
+    private String title;
+    private String originalTitle;
+    private String overview;
+    private String posterImg;
+    private String backgroundImg;
+    private double popcorn;
+    private double voteAverage;
+    private LocalDate releaseDate;
+    private int runtime;
+    private int productionYear;
+    private String productionCountry;
+    private String ageRating;
+
+    private List<GenreDTO> genres;
+    private List<String> images;
+    private List<String> videos;
+    private List<ProviderDTO> providers;
+    private List<CastResponseDTO> casts;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/MovieListPageResponseDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/MovieListPageResponseDTO.java
@@ -1,0 +1,17 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MovieListPageResponseDTO {
+
+    private long totalElements; // 잔체 요소 수
+    private int totalPages; // 전체 페이지 수
+    private int page; // 현재 페이지(0부터 시작)
+    private int size; // 요청한 페이지 사이즈
+    private List<MovieListResponseDTO> content;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/MovieListResponseDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/MovieListResponseDTO.java
@@ -1,0 +1,16 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class MovieListResponseDTO {
+
+    private Long tmdbId;
+    private String title;
+    private LocalDate releaseDate;
+    private String image;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/ProviderDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/ProviderDTO.java
@@ -1,0 +1,11 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProviderDTO {
+    private String providerName;
+    private String providerType;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/dto/SearchRequestIdDTO.java
+++ b/src/main/java/com/flipflick/backend/api/movie/dto/SearchRequestIdDTO.java
@@ -1,0 +1,10 @@
+package com.flipflick.backend.api.movie.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchRequestIdDTO {
+    private Long tmdbId;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/Genre.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/Genre.java
@@ -1,0 +1,28 @@
+package com.flipflick.backend.api.movie.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "genre")
+@AllArgsConstructor
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private Long tmdbId; // tmdb ID
+    private String genreName; // tmdb 장르명
+
+    @OneToMany(mappedBy = "genre", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MovieGenre> movieGenres = new ArrayList<>();
+
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/Movie.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/Movie.java
@@ -1,0 +1,68 @@
+package com.flipflick.backend.api.movie.entity;
+
+import com.flipflick.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.BatchSize;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "movie")
+public class Movie extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private Long tmdbId;            // TMDB 영화 ID
+
+    private String title;           // 제목
+    private String originalTitle;   // 원제목
+
+    @Lob
+    @Column(columnDefinition = "CLOB")
+    private String overview;        // 줄거리
+
+    private String posterImg;       // 포스터
+    private String backgroundImg;   // 배경 이미지 (backdrop)
+
+    private double popcorn;         // 팝콘지수
+    private double voteAverage;     // 우리 자체 평점 (초기 0)
+
+    private long likeCnt;           // 좋아요
+    private long hateCnt;           // 싫어요
+
+    private LocalDate releaseDate;  // 개봉일
+    private int runtime;            // 상영 시간
+
+    private int productionYear;     // 제작연도
+    private String productionCountry; // 제작국가
+    private String ageRating;      // 연령등급
+
+    @BatchSize(size = 50)
+    @OrderColumn(name = "genre_order")
+    @Builder.Default
+    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MovieGenre> movieGenres = new ArrayList<>();
+
+    @BatchSize(size = 50)
+    @OrderColumn(name = "media_order")
+    @Builder.Default
+    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MovieImageVideo> media = new ArrayList<>();
+
+    @BatchSize(size = 50)
+    @OrderColumn(name = "provider_order")
+    @Builder.Default
+    @OneToMany(mappedBy = "movie", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MovieProvider> providers = new ArrayList<>();
+
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/MovieGenre.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/MovieGenre.java
@@ -1,0 +1,24 @@
+package com.flipflick.backend.api.movie.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "movie_genre")
+@AllArgsConstructor
+public class MovieGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "genre_id")
+    private Genre genre;
+
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/MovieImageVideo.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/MovieImageVideo.java
@@ -1,0 +1,25 @@
+package com.flipflick.backend.api.movie.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "movie_image_video")
+@AllArgsConstructor
+public class MovieImageVideo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    private MovieMediaType movieMediaType;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "movie_id")
+    private Movie movie;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/MovieMediaType.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/MovieMediaType.java
@@ -1,0 +1,5 @@
+package com.flipflick.backend.api.movie.entity;
+
+public enum MovieMediaType {
+    IMAGE, VIDEO
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/MovieProvider.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/MovieProvider.java
@@ -1,0 +1,27 @@
+package com.flipflick.backend.api.movie.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "movie_provider")
+@AllArgsConstructor
+public class MovieProvider {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_type", nullable = false)
+    private ProviderType providerType;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "movie_id")
+    private Movie movie;
+
+    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "provider_id")
+    private Provider provider;
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/Provider.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/Provider.java
@@ -1,0 +1,27 @@
+package com.flipflick.backend.api.movie.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Table(name = "provider")
+@AllArgsConstructor
+public class Provider {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private Long tmdbId; // tmdb ID (provider_id)
+    private String providerName; // tmdb 제공사명 (provider_name)
+
+    @OneToMany(mappedBy = "provider", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MovieProvider> movieProviders = new ArrayList<>();
+}

--- a/src/main/java/com/flipflick/backend/api/movie/entity/ProviderType.java
+++ b/src/main/java/com/flipflick/backend/api/movie/entity/ProviderType.java
@@ -1,0 +1,6 @@
+package com.flipflick.backend.api.movie.entity;
+
+public enum ProviderType {
+
+    RENT, FLATRATE, BUY
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/GenreRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/GenreRepository.java
@@ -1,0 +1,13 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+
+    Optional<Genre> findByTmdbId(Long tmdbId);
+    List<Genre> findByTmdbIdIn(List<Long> tmdbIds);
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/MovieGenreRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/MovieGenreRepository.java
@@ -1,0 +1,7 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.MovieGenre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieGenreRepository extends JpaRepository<MovieGenre, Long> {
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/MovieImageVideoRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/MovieImageVideoRepository.java
@@ -1,0 +1,7 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.MovieImageVideo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieImageVideoRepository extends JpaRepository<MovieImageVideo, Long> {
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/MovieProviderRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/MovieProviderRepository.java
@@ -1,0 +1,7 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.MovieProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieProviderRepository extends JpaRepository<MovieProvider, Long> {
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/MovieRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/MovieRepository.java
@@ -1,0 +1,17 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.Movie;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+
+    @EntityGraph(attributePaths = {
+            "movieGenres.genre",
+            "media",
+            "providers.provider"
+    })
+    Optional<Movie> findWithAllByTmdbId(Long tmdbId);
+}

--- a/src/main/java/com/flipflick/backend/api/movie/repository/ProviderRepository.java
+++ b/src/main/java/com/flipflick/backend/api/movie/repository/ProviderRepository.java
@@ -1,0 +1,14 @@
+package com.flipflick.backend.api.movie.repository;
+
+import com.flipflick.backend.api.movie.entity.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProviderRepository extends JpaRepository<Provider, Long> {
+
+    Optional<Provider> findByTmdbId(Long tmdbId);
+    List<Provider> findByTmdbIdIn(List<Long> tmdbIds);
+
+}

--- a/src/main/java/com/flipflick/backend/api/movie/service/MovieService.java
+++ b/src/main/java/com/flipflick/backend/api/movie/service/MovieService.java
@@ -1,0 +1,255 @@
+package com.flipflick.backend.api.movie.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.flipflick.backend.api.movie.dto.*;
+import com.flipflick.backend.api.movie.entity.*;
+import com.flipflick.backend.api.movie.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MovieService {
+
+    @Value("${tmdb.api.key}")
+    private String apiKey;
+
+    @Value("${tmdb.api.image-base-url}")
+    private String imageBaseUrl;
+
+    private final WebClient tmdbWebClient;
+    private final MovieRepository movieRepository;
+    private final GenreRepository genreRepository;
+    private final ProviderRepository providerRepository;
+
+    // 영화 상세 조회 메서드(DB에 영화데이터가 없으면 TMDB호출 및 저장후 반환)
+    @Transactional
+    public MovieDetailResponseDTO viewMovieDetail(SearchRequestIdDTO dto) {
+        Long tmdbId = dto.getTmdbId();
+
+        // 페치 조인으로 genre, media, provider 모두 미리 가져옴
+        Movie movie = movieRepository.findWithAllByTmdbId(tmdbId)
+                .orElseGet(() -> fetchAndSaveMovie(tmdbId));
+
+        List<CastResponseDTO> casts = fetchCasts(tmdbId);
+
+        return MovieDetailResponseDTO.builder()
+                .tmdbId(movie.getTmdbId())
+                .title(movie.getTitle())
+                .originalTitle(movie.getOriginalTitle())
+                .overview(movie.getOverview())
+                .posterImg(movie.getPosterImg())
+                .backgroundImg(movie.getBackgroundImg())
+                .voteAverage(movie.getVoteAverage())
+                .popcorn(movie.getPopcorn())
+                .releaseDate(movie.getReleaseDate())
+                .productionYear(movie.getProductionYear())
+                .productionCountry(movie.getProductionCountry())
+                .ageRating(movie.getAgeRating())
+                .runtime(movie.getRuntime())
+                .genres(movie.getMovieGenres().stream()
+                        .map(mg -> GenreDTO.builder()
+                                .tmdbId(mg.getGenre().getTmdbId())
+                                .genreName(mg.getGenre().getGenreName())
+                                .build())
+                        .collect(Collectors.toList()))
+                .images(movie.getMedia().stream()
+                        .filter(mv -> mv.getMovieMediaType() == MovieMediaType.IMAGE)
+                        .map(MovieImageVideo::getUrl)
+                        .collect(Collectors.toList()))
+                .videos(movie.getMedia().stream()
+                        .filter(mv -> mv.getMovieMediaType() == MovieMediaType.VIDEO)
+                        .map(MovieImageVideo::getUrl)
+                        .collect(Collectors.toList()))
+                .providers(movie.getProviders().stream()
+                        .map(mp -> ProviderDTO.builder()
+                                .providerName(mp.getProvider().getProviderName())
+                                .providerType(mp.getProviderType().name())
+                                .build())
+                        .collect(Collectors.toList()))
+                .casts(casts)
+                .build();
+    }
+
+    // TMDB API 호출 및 DB 저장
+    private Movie fetchAndSaveMovie(Long tmdbId) {
+        JsonNode root = tmdbWebClient.get()
+                .uri(builder -> builder
+                        .path("/movie/{id}")
+                        .queryParam("api_key", apiKey)
+                        .queryParam("language", "ko-KR")
+                        .queryParam("include_image_language", "ko,null")
+                        .queryParam("append_to_response", "videos,images,watch/providers,release_dates,credits")
+                        .build(tmdbId))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if (root == null) {
+            throw new RuntimeException("TMDB 응답이 없습니다.");
+        }
+
+        // 개봉일 추출
+        LocalDate relDate = LocalDate.parse(root.get("release_date").asText());
+        int productionYear = relDate.getYear();
+
+        // 한국 연령 등급 추출
+        String ageCert = "";
+        for (JsonNode node : root.path("release_dates").path("results")) {
+            if ("KR".equals(node.path("iso_3166_1").asText())) {
+                ageCert = node.path("release_dates").get(0).path("certification").asText();
+                break;
+            }
+        }
+
+        // 제작국가 추출 (첫번째)
+        String prodCountry = "";
+        JsonNode pcArr = root.path("production_countries");
+        if (pcArr.isArray() && pcArr.size() > 0) {
+            prodCountry = pcArr.get(0).path("name").asText();
+        }
+
+        // 영화 엔티티 필드
+        Movie movie = Movie.builder()
+                .tmdbId(root.get("id").asLong())
+                .title(root.get("title").asText())
+                .originalTitle(root.get("original_title").asText())
+                .overview(root.get("overview").asText())
+                .posterImg(root.path("poster_path").isNull()
+                        ? null
+                        : imageBaseUrl + root.path("poster_path").asText())
+                .backgroundImg(root.path("backdrop_path").isNull()
+                        ? null
+                        : imageBaseUrl + root.path("backdrop_path").asText())
+                .popcorn(0.0)
+                .voteAverage(0.0)
+                .releaseDate(relDate)
+                .productionYear(productionYear)
+                .productionCountry(prodCountry)
+                .ageRating(ageCert)
+                .runtime(root.get("runtime").asInt())
+                .build();
+
+        // 장르 조회 및 저장
+        List<Long> genreIds = new ArrayList<>();
+        root.path("genres").forEach(g -> genreIds.add(g.get("id").asLong()));
+        Map<Long, Genre> existingGenres = genreRepository.findByTmdbIdIn(genreIds)
+                .stream().collect(Collectors.toMap(Genre::getTmdbId, g -> g));
+        for (JsonNode g : root.path("genres")) {
+            long gid = g.get("id").asLong();
+            Genre genre = existingGenres.computeIfAbsent(gid, id ->
+                    genreRepository.save(Genre.builder()
+                            .tmdbId(id)
+                            .genreName(g.get("name").asText())
+                            .build()));
+            movie.getMovieGenres().add(
+                    MovieGenre.builder().movie(movie).genre(genre).build()
+            );
+        }
+
+        // 이미지 저장
+        root.path("images").path("posters")
+                .forEach(img -> addImage(movie, img.path("file_path").asText(null)));
+        root.path("images").path("backdrops")
+                .forEach(img -> addImage(movie, img.path("file_path").asText(null)));
+
+        // 비디오 저장
+        root.path("videos").path("results").forEach(v -> {
+            if ("YouTube".equals(v.path("site").asText())) {
+                movie.getMedia().add(
+                        MovieImageVideo.builder()
+                                .url("https://www.youtube.com/watch?v=" + v.path("key").asText())
+                                .movieMediaType(MovieMediaType.VIDEO)
+                                .movie(movie)
+                                .build()
+                );
+            }
+        });
+
+        // 제공사 조회 및 저장 (한국기준)
+        JsonNode kr = root.path("watch/providers").path("results").path("KR");
+        if (!kr.isMissingNode()) {
+            List<Long> pidList = new ArrayList<>();
+            kr.path("flatrate").forEach(p -> pidList.add(p.get("provider_id").asLong()));
+            kr.path("rent").forEach(p -> pidList.add(p.get("provider_id").asLong()));
+            kr.path("buy").forEach(p -> pidList.add(p.get("provider_id").asLong()));
+
+            Map<Long, Provider> existingProvs = providerRepository.findByTmdbIdIn(pidList)
+                    .stream().collect(Collectors.toMap(Provider::getTmdbId, p -> p));
+
+            kr.path("flatrate").forEach(p -> addProvider(movie, p, ProviderType.FLATRATE, existingProvs));
+            kr.path("rent").forEach(p -> addProvider(movie, p, ProviderType.RENT, existingProvs));
+            kr.path("buy").forEach(p -> addProvider(movie, p, ProviderType.BUY, existingProvs));
+        }
+
+        return movieRepository.save(movie);
+    }
+
+    private void addImage(Movie movie, String path) {
+        if (path != null) {
+            movie.getMedia().add(
+                    MovieImageVideo.builder()
+                            .url(imageBaseUrl + path)
+                            .movieMediaType(MovieMediaType.IMAGE)
+                            .movie(movie)
+                            .build()
+            );
+        }
+    }
+
+    private void addProvider(Movie movie, JsonNode p, ProviderType type, Map<Long, Provider> cache) {
+        long pid = p.get("provider_id").asLong();
+        Provider prov = cache.computeIfAbsent(pid, id ->
+                providerRepository.save(
+                        Provider.builder()
+                                .tmdbId(id)
+                                .providerName(p.get("provider_name").asText())
+                                .build()
+                )
+        );
+        movie.getProviders().add(
+                MovieProvider.builder()
+                        .movie(movie)
+                        .provider(prov)
+                        .providerType(type)
+                        .build()
+        );
+    }
+
+    // 배우 정보 호출
+    private List<CastResponseDTO> fetchCasts(Long tmdbId) {
+        JsonNode root = tmdbWebClient.get()
+                .uri(builder -> builder
+                        .path("/movie/{id}/credits")
+                        .queryParam("api_key", apiKey)
+                        .queryParam("language", "ko-KR")
+                        .build(tmdbId))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        if (root == null || !root.has("cast")) {
+            return Collections.emptyList();
+        }
+
+        return StreamSupport.stream(root.get("cast").spliterator(), false)
+                .map(c -> CastResponseDTO.builder()
+                        .id(c.get("id").asLong())
+                        .name(c.get("name").asText())
+                        .profileImg(c.path("profile_path").isNull()
+                                ? null
+                                : imageBaseUrl + c.get("profile_path").asText())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/flipflick/backend/api/search/controller/SearchController.java
+++ b/src/main/java/com/flipflick/backend/api/search/controller/SearchController.java
@@ -1,0 +1,37 @@
+package com.flipflick.backend.api.search.controller;
+
+import com.flipflick.backend.api.movie.dto.MovieListPageResponseDTO;
+import com.flipflick.backend.api.search.dto.SearchRequestDTO;
+import com.flipflick.backend.api.search.service.SearchService;
+import com.flipflick.backend.common.response.ApiResponse;
+import com.flipflick.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+@Tag(name="Search", description = "검색 관련 API 입니다.")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "영화 검색 API", description = "키워드, 페이지를 받아 영화 리스트를 조회합니다 <br> page는 1 이상")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "영화 리스트 조회 성공")
+    })
+    @PostMapping("/movie")
+    public ResponseEntity<ApiResponse<MovieListPageResponseDTO>> searchMovies(@RequestBody SearchRequestDTO searchRequestDTO) {
+
+        MovieListPageResponseDTO movieListPageResponseDTO = searchService.searchMovieList(searchRequestDTO);
+        return ApiResponse.success(SuccessStatus.SEND_MOVIE_LIST_SUCCESS, movieListPageResponseDTO);
+    }
+
+}

--- a/src/main/java/com/flipflick/backend/api/search/dto/SearchRequestDTO.java
+++ b/src/main/java/com/flipflick/backend/api/search/dto/SearchRequestDTO.java
@@ -1,0 +1,12 @@
+package com.flipflick.backend.api.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchRequestDTO {
+
+    private String query;
+    private int page;
+}

--- a/src/main/java/com/flipflick/backend/api/search/dto/TmdbMovieSearchResponseDTO.java
+++ b/src/main/java/com/flipflick/backend/api/search/dto/TmdbMovieSearchResponseDTO.java
@@ -1,0 +1,43 @@
+package com.flipflick.backend.api.search.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Builder
+public class TmdbMovieSearchResponseDTO {
+
+    private int page;
+
+    @JsonProperty("total_results")
+    private long totalResults;
+
+    @JsonProperty("total_pages")
+    private int totalPages;
+
+    private List<TmdbMovie> results;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Builder
+    public static class TmdbMovie {
+        @JsonProperty("id")
+        private Long tmdbId;
+
+        private String title;
+
+        @JsonProperty("release_date")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        private LocalDate releaseDate;
+
+        @JsonProperty("poster_path")
+        private String imagePath;
+    }
+}

--- a/src/main/java/com/flipflick/backend/api/search/service/SearchService.java
+++ b/src/main/java/com/flipflick/backend/api/search/service/SearchService.java
@@ -1,0 +1,91 @@
+package com.flipflick.backend.api.search.service;
+
+import com.flipflick.backend.api.movie.dto.MovieListPageResponseDTO;
+import com.flipflick.backend.api.movie.dto.MovieListResponseDTO;
+import com.flipflick.backend.api.search.dto.TmdbMovieSearchResponseDTO;
+import com.flipflick.backend.api.search.dto.SearchRequestDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class SearchService {
+
+    @Value("${tmdb.api.key}")
+    private String apiKey;
+
+    @Value("${tmdb.api.image-base-url}")
+    private String imageBaseUrl;
+
+    private final WebClient tmdbWebClient;
+
+    public SearchService(WebClient tmdbWebClient) {
+        this.tmdbWebClient = tmdbWebClient;
+    }
+
+    public MovieListPageResponseDTO searchMovieList(SearchRequestDTO searchRequestDTO) {
+
+        // 1) WebClient로 TMDB 검색 API 호출
+        TmdbMovieSearchResponseDTO tmdb = tmdbWebClient.get()
+                .uri(uriBuilder -> buildSearchUri(uriBuilder, searchRequestDTO))
+                .retrieve()
+                .bodyToMono(TmdbMovieSearchResponseDTO.class)
+                .block();
+
+        // null/빈 결과 처리
+        if (tmdb == null || tmdb.getResults() == null) {
+            return MovieListPageResponseDTO.builder()
+                    .totalElements(0)
+                    .totalPages(0)
+                    .page(searchRequestDTO.getPage())
+                    .size(0)
+                    .content(Collections.emptyList())
+                    .build();
+        }
+
+        // 개봉일자 최신순으로 정렬
+        List<MovieListResponseDTO> content = tmdb.getResults().stream()
+                .sorted(Comparator.comparing(
+                        TmdbMovieSearchResponseDTO.TmdbMovie::getReleaseDate,
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                    )
+                        .reversed()
+                )
+                .map(m -> MovieListResponseDTO.builder()
+                        .tmdbId(m.getTmdbId())
+                        .title(m.getTitle())
+                        .releaseDate(m.getReleaseDate())
+                        .image(m.getImagePath() != null
+                                ? imageBaseUrl + m.getImagePath()
+                                : null)
+                        .build())
+                .collect(Collectors.toList());
+
+        return MovieListPageResponseDTO.builder()
+                .totalElements(tmdb.getTotalResults())
+                .totalPages(tmdb.getTotalPages())
+                .page(tmdb.getPage())
+                .size(content.size())
+                .content(content)
+                .build();
+    }
+
+    // URI 빌더 메서드
+    private java.net.URI buildSearchUri(UriBuilder uriBuilder, SearchRequestDTO dto) {
+        return uriBuilder
+                .path("/search/movie")
+                .queryParam("api_key", apiKey)
+                .queryParam("language", "ko-KR")
+                .queryParam("query", dto.getQuery())
+                .queryParam("page", dto.getPage())
+                .build();
+    }
+}

--- a/src/main/java/com/flipflick/backend/common/config/webclient/WebClientConfig.java
+++ b/src/main/java/com/flipflick/backend/common/config/webclient/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.flipflick.backend.common.config.webclient;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${tmdb.api.url}")
+    private String apiUrl;
+
+    @Bean
+    public WebClient tmdbWebClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(apiUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/flipflick/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/flipflick/backend/common/response/ErrorStatus.java
@@ -39,7 +39,7 @@ public enum ErrorStatus {
     /**
      * 500 SERVER_ERROR
      */
-    PASSPORT_SIGN_ERROR_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"Passport 서명 검증 중 오류가 발생했습니다."),
+    NO_RESPONSE_TMDB_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "데이터 조회 중 에러가 발생하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/flipflick/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/flipflick/backend/common/response/SuccessStatus.java
@@ -16,6 +16,8 @@ public enum SuccessStatus {
     SEND_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
     SEND_REISSUE_TOKEN_SUCCESS(HttpStatus.OK,"토큰 재발급 성공"),
     SEND_HEALTH_SUCCESS(HttpStatus.OK,"서버 상태 OK"),
+    SEND_MOVIE_DETAIL_SUCCESS(HttpStatus.OK,"영화 상세 조회 성공"),
+    SEND_MOVIE_LIST_SUCCESS(HttpStatus.OK,"영화 리스트 조회 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #4

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 영화 리스트 검색 API 를 구현하였습니다.
- 영화 상세보기 조회 API 를 구현하였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 영화 상세보기 API 최적화를 진행하였습니다
[사용기술]
- WebClient (RestTemplate처럼 요청-응답 간 스레드가 블로킹되지 않아, IO 대기 중에도 다른 요청을 처리 가능 -> 스레드풀 효율 업)
- tmdbId 인덱스 추가 : 기존 풀 테이블 스캔 -> 인덱스 탐색 (O(log N)) / 조회 지연 수십 ms → 1 ms 이하로 단축
- 배치저장(Batch Insert/update) : SQL 왕복 횟수 감소, 1 건씩 INSERT/UPDATE → 한 번에 50건 처리
- 지연로딩 -> 페치 조인 : N+1 방지 / 추가 쿼리 없이 관계된 데이터(미디어, 장르, 제공처) 일괄 조회
- 한번의 조회 : N+1 방지 / 장르·제공처 조회를 루프 안에서 매번 하지 않고, 한 번의 SELECT … WHERE tmdb_id IN (…)로 처리 -> DB 왕복 횟수 N→1