### PR TITLE
[FIX] webClient 버퍼 크기 조정

### DIFF
--- a/src/main/java/com/flipflick/backend/common/config/webclient/WebClientConfig.java
+++ b/src/main/java/com/flipflick/backend/common/config/webclient/WebClientConfig.java
@@ -3,18 +3,26 @@ package com.flipflick.backend.common.config.webclient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
 
-    @Value("${tmdb.api.url}")
-    private String apiUrl;
-
     @Bean
-    public WebClient tmdbWebClient(WebClient.Builder builder) {
+    public WebClient tmdbWebClient(WebClient.Builder builder,
+                                   @Value("${tmdb.api.url}") String baseUrl) {
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        // 10 * 1024 * 1024 = 10MB
+                        .maxInMemorySize(10 * 1024 * 1024)
+                )
+                .build();
+
         return builder
-                .baseUrl(apiUrl)
+                .baseUrl(baseUrl)
+                .exchangeStrategies(strategies)
                 .build();
     }
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #13

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- webClient 버퍼 크기를 기존 256kb 에서 10mb로 조정하였습니다.