### PR TITLE
[FIX] SuccessStatus 중복 문구 삭제

### DIFF
--- a/src/main/java/com/flipflick/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/flipflick/backend/common/response/SuccessStatus.java
@@ -48,7 +48,6 @@ public enum SuccessStatus {
     CHECK_EMAIL_DUPLICATE(HttpStatus.OK, "이메일 중복 검사 결과입니다."),
     CHECK_NICKNAME_DUPLICATE(HttpStatus.OK, "닉네임 중복 검사 결과입니다."),
     IMAGE_DELETE_SUCCESS(HttpStatus.OK,"이미지 삭제 성공"),
-    REISSUE_SUCCESS(HttpStatus.OK, "access토큰 재발급 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #50

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- SuccessStatus 중복 문구를 삭제하였습니다.